### PR TITLE
Use log based axis for node graphs.

### DIFF
--- a/cinnamon/2.2.x/grafana/4.x/elasticsearch/node-metrics-dashboard.json
+++ b/cinnamon/2.2.x/grafana/4.x/elasticsearch/node-metrics-dashboard.json
@@ -34,6 +34,8 @@
             "legend": {
               "avg": false,
               "current": false,
+              "hideEmpty": true,
+              "hideZero": true,
               "max": false,
               "min": false,
               "show": false,
@@ -163,7 +165,7 @@
               {
                 "format": "short",
                 "label": "Phi Accrual Value",
-                "logBase": 1,
+                "logBase": 2,
                 "max": null,
                 "min": null,
                 "show": true
@@ -222,9 +224,14 @@
           "name": "SelfNodes",
           "options": [],
           "query": "{\"find\": \"terms\", \"field\": \"self-node\"}",
-          "refresh": 1,
+          "refresh": 2,
           "regex": "",
-          "type": "query"
+          "type": "query",
+          "label": null,
+          "sort": 0,
+          "allValue": null,
+          "tagsQuery": null,
+          "tagValuesQuery": null
         },
         {
           "current": {},
@@ -235,9 +242,14 @@
           "name": "RemoteNodes",
           "options": [],
           "query": "{\"find\": \"terms\", \"field\": \"remote-node\", \"query\":\"self-node:$SelfNodes\"}",
-          "refresh": 1,
+          "refresh": 2,
           "regex": "",
-          "type": "query"
+          "type": "query",
+          "label": null,
+          "sort": 0,
+          "allValue": null,
+          "tagsQuery": null,
+          "tagValuesQuery": null
         }
       ]
     },

--- a/cinnamon/2.2.x/grafana/4.x/graphite/node-metrics.json
+++ b/cinnamon/2.2.x/grafana/4.x/graphite/node-metrics.json
@@ -1,8 +1,10 @@
 {
   "id": null,
   "title": "Node Metrics",
-  "originalTitle": "Node Metrics",
-  "tags": [],
+  "tags": [
+    "akka",
+    "demo"
+  ],
   "style": "dark",
   "timezone": "browser",
   "editable": false,
@@ -50,7 +52,7 @@
         "name": "SelfNodes",
         "options": [],
         "query": "*.gauges.servers.*.apps.*.metrics.self-nodes.*",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "sort": 0,
         "tagValuesQuery": null,
@@ -68,7 +70,7 @@
         "name": "RemoteNodes",
         "options": [],
         "query": "*.gauges.servers.*.apps.*.metrics.self-nodes.$SelfNodes.remote-nodes.*",
-        "refresh": 1,
+        "refresh": 2,
         "regex": "",
         "sort": 0,
         "tagValuesQuery": null,
@@ -82,7 +84,7 @@
   },
   "refresh": false,
   "schemaVersion": 13,
-  "version": 6,
+  "version": 8,
   "links": [],
   "gnetId": null,
   "rows": [
@@ -101,6 +103,8 @@
           "legend": {
             "avg": false,
             "current": false,
+            "hideEmpty": true,
+            "hideZero": true,
             "max": false,
             "min": false,
             "show": false,
@@ -157,7 +161,7 @@
             {
               "format": "short",
               "label": null,
-              "logBase": 1,
+              "logBase": 2,
               "max": null,
               "min": null,
               "show": true


### PR DESCRIPTION
Also uses refresh on time for dashboard instead of on dashboard load. This will ensure that only graphs that have available data in the selected time span are shown.